### PR TITLE
Fix USB BULK buffers on 16F1459 and simplify code

### DIFF
--- a/p8/include/pinguino/core/usb/picUSB.h
+++ b/p8/include/pinguino/core/usb/picUSB.h
@@ -308,10 +308,6 @@ typedef struct
     #define BD_ADDR                 0x2000
     #define PA_ADDR                 0x2020 // (BD_ADDR + (2*USB_MAX_ENDPOINTS*sizeof(BufferDescriptorTable))
     #define TR_ADDR                 0x2028 // (PA_ADDR + EP0_BUFFER_SIZE)
-    #ifdef USB_USE_CDC
-    #define RX_ADDR                 0x2030 // (TR_ADDR + EP0_BUFFER_SIZE)
-    #define TX_ADDR                 0x2050 // (RX_ADDR + USB_CDC_OUT_EP_SIZE)
-    #endif
     
 #elif defined(__18f13k50) || defined(__18f14k50)
 

--- a/p8/include/pinguino/core/usb/usb_bulk.c
+++ b/p8/include/pinguino/core/usb/usb_bulk.c
@@ -13,12 +13,11 @@
 
 //#ifdef USB_USE_BULK
 
-#ifdef __XC8
-// CDC specific buffers
-volatile u8 BULKRxBuffer[BULK_BULK_OUT_SIZE] @ (0x500);
-volatile u8 BULKTxBuffer[BULK_BULK_IN_SIZE] @ (0x540);
-#else
 // Put USB I/O buffers into dual port RAM.
+#ifdef __XC8
+volatile u8 __section("usbram5") BULKRxBuffer[BULK_BULK_OUT_SIZE];
+volatile u8 __section("usbram5") BULKTxBuffer[BULK_BULK_IN_SIZE];
+#else
 #pragma udata usbram5 BULKRxBuffer BULKTxBuffer
 volatile u8 BULKRxBuffer[BULK_BULK_OUT_SIZE];
 volatile u8 BULKTxBuffer[BULK_BULK_IN_SIZE];

--- a/p8/include/pinguino/core/usb/usb_cdc.c
+++ b/p8/include/pinguino/core/usb/usb_cdc.c
@@ -23,16 +23,8 @@ extern u32 cdc_baudrate;
 
 #ifdef __XC8__
     //extern volatile BufferDescriptorTable ep_bdt[2*USB_MAX_ENDPOINTS];
-    #if defined(__16F1459)
-        #define RX_ADDR_TAG @##RX_ADDR
-        #define TX_ADDR_TAG @##TX_ADDR
-        u8 __section("usbram5") dummy; // to prevent a compilation error
-        volatile u8 CDCRxBuffer[USB_CDC_OUT_EP_SIZE] RX_ADDR_TAG; //@ 0x2028; //0x2098;
-        volatile u8 CDCTxBuffer[USB_CDC_IN_EP_SIZE]  TX_ADDR_TAG; //@ 0x2030; //0x20D8;
-    #else
-        volatile u8 __section("usbram5") CDCRxBuffer[USB_CDC_OUT_EP_SIZE];
-        volatile u8 __section("usbram5") CDCTxBuffer[USB_CDC_IN_EP_SIZE];
-    #endif
+    volatile u8 __section("usbram5") CDCRxBuffer[USB_CDC_OUT_EP_SIZE];
+    volatile u8 __section("usbram5") CDCTxBuffer[USB_CDC_IN_EP_SIZE];
 #else // SDCC
     //extern volatile BufferDescriptorTable __at BD_ADDR ep_bdt[2*USB_MAX_ENDPOINTS];
     #pragma udata usbram5 CDCRxBuffer CDCTxBuffer


### PR DESCRIPTION
The USB bulk code was not updated for 16F1459. This leaves the RX and TX
buffers outside of dual-port RAM, so it doesn't work. This commit
relocates the buffers to the right location. Instead of using absolute
addressing, the __section() specifier is used to give the compiler the
flexibility to place the buffers anywhere in the given section. This
change requires commit 611afb4 to pinguino-ide, which updates the
usbram5 section to the correct processor-specific memory ranges.

This commit also updates the CDC code to allocate those buffers in the
same way.