### PR TITLE
Oled lib fix for p8 i2c

### DIFF
--- a/p8/include/pinguino/libraries/oled.c
+++ b/p8/include/pinguino/libraries/oled.c
@@ -414,9 +414,12 @@ void OLED_init(u8 module, ...)
     #elif defined(OLEDUSEI2C1) ||defined(OLEDUSEI2C2)
     //OLED.init(I2C, address);
     OLED_I2CADDR = va_arg(args, int);
-    //I2C_init(module, I2C_MASTER_MODE, I2C_100KHZ); // OK
-    //I2C_init(module, I2C_MASTER_MODE, I2C_400KHZ); // OK
-    I2C_init(module, I2C_MASTER_MODE, I2C_1MHZ); // OK
+        #if defined(__18f2550) || defined(__18f4550)
+        //I2C_init(module, I2C_MASTER_MODE, I2C_100KHZ); // OK
+        I2C_init(module, I2C_MASTER_MODE, I2C_400KHZ); // OK
+        #else
+        I2C_init(module, I2C_MASTER_MODE, I2C_1MHZ); // OK
+        #endif
 
     ///-----------------------------------------------------------------
 
@@ -747,7 +750,7 @@ void OLED_setFont(u8 module, const u8 *font)
     TODO:
         check x and y
     ------------------------------------------------------------------*/
-void OLED_setXY(u8 module, u8 x, u8 y)
+    void OLED_setXY(u8 module, u8 x, u8 y)
 {
     if ( x >= OLED_DISPLAY_WIDTH || y >= (OLED_DISPLAY_HEIGHT) ) return;
 

--- a/p8/include/pinguino/libraries/oled.h
+++ b/p8/include/pinguino/libraries/oled.h
@@ -95,7 +95,7 @@
     #define OLED_DISPLAY_WIDTH_BITS   7
     #define OLED_DISPLAY_WIDTH_MASK   0x7F
 
-    #ifdef OLED_132X64
+    #if defined(OLED_132X64)
         // SH1106 panel is 128 pixels wide,
         // controller RAM has space for 132,
         // it's centered so add an offset to RAM address.
@@ -104,7 +104,7 @@
         #define OLED_DISPLAY_ROWS     8
         #define OLED_DISPLAY_ROW_BITS 3
         #define OLED_DISPLAY_ROW_MASK 0x07
-    #elif OLED_132X32
+    #elif defined(OLED_132X32)
         // SH1106 panel is 128 pixels wide,
         // controller RAM has space for 132,
         // it's centered so add an offset to RAM address.
@@ -113,13 +113,13 @@
         #define OLED_DISPLAY_ROWS     4
         #define OLED_DISPLAY_ROW_BITS 2
         #define OLED_DISPLAY_ROW_MASK 0x03
-    #elif OLED_128X64
+    #elif defined(OLED_128X64)
         #define OLED_DISPLAY_WIDTH    128
         #define OLED_RAM_OFFSET       0
         #define OLED_DISPLAY_ROWS     8
         #define OLED_DISPLAY_ROW_BITS 3
         #define OLED_DISPLAY_ROW_MASK 0x07
-    #elif OLED_128X32
+    #elif defined(OLED_128X32)
         #define OLED_DISPLAY_WIDTH    128
         #define OLED_RAM_OFFSET       0
         #define OLED_DISPLAY_ROWS     4


### PR DESCRIPTION

![IMG_20220505_025000](https://user-images.githubusercontent.com/60434183/166872199-fba3e64e-635e-4553-a9fc-0d4ab4cda21a.jpg)
Fix OLED lib for P18FX550 microcontrollers and sdd1306 display (i2c protocol) .